### PR TITLE
ChoiceProvider

### DIFF
--- a/Attributes/ChoiceProviderAttribute.cs
+++ b/Attributes/ChoiceProviderAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace DSharpPlus.SlashCommands
+{
+    /// <summary>
+    /// Sets a IChoiceProvider for a command options. ChoiceProviders can be used to provide
+    /// DiscordApplicationCommandOptionChoice from external sources such as a database.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
+    public class ChoiceProviderAttribute : Attribute
+    {
+
+        public Type ProviderType { get; }
+        
+        public ChoiceProviderAttribute(Type providerType)
+        {
+            ProviderType = providerType;
+        }
+    }
+}

--- a/IChoiceProvider.cs
+++ b/IChoiceProvider.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.SlashCommands
+{
+    public interface IChoiceProvider
+    {
+        Task<IEnumerable<DiscordApplicationCommandOptionChoice>> Provider();
+    }
+}

--- a/SlashCommandsExtension.cs
+++ b/SlashCommandsExtension.cs
@@ -104,7 +104,7 @@ namespace DSharpPlus.SlashCommands
                                     throw new ArgumentException($"The first argument must be an InteractionContext!");
                                 parameters = parameters.Skip(1).ToArray();
 
-                                var options = ParseParameters(parameters);
+                                var options = await ParseParameters(parameters);
     
                                 var subpayload = new DiscordApplicationCommandOption(commandattribute.Name, commandattribute.Description, ApplicationCommandOptionType.SubCommand, null, null, options);
 
@@ -131,7 +131,7 @@ namespace DSharpPlus.SlashCommands
                                     if (!ReferenceEquals(parameters.First().ParameterType, typeof(InteractionContext)))
                                         throw new ArgumentException($"The first argument must be an InteractionContext!");
                                     parameters = parameters.Skip(1).ToArray();
-                                    suboptions = suboptions.Concat(ParseParameters(parameters)).ToList();
+                                    suboptions = suboptions.Concat(await ParseParameters(parameters)).ToList();
                                     
                                     var subsubpayload = new DiscordApplicationCommandOption(commatt.Name, commatt.Description, ApplicationCommandOptionType.SubCommand, null, null, suboptions);
                                     options.Add(subsubpayload);
@@ -157,7 +157,7 @@ namespace DSharpPlus.SlashCommands
                             if (parameters.Length == 0 || parameters == null || !ReferenceEquals(parameters.FirstOrDefault()?.ParameterType, typeof(InteractionContext)))
                                 throw new ArgumentException($"The first argument must be an InteractionContext!");
                             parameters = parameters.Skip(1).ToArray();
-                            options = options.Concat(ParseParameters(parameters)).ToList();
+                            options = options.Concat(await ParseParameters(parameters)).ToList();
 
                             InternalCommandMethods.Add(new CommandMethod { Method = method, Name = commandattribute.Name, ParentClass = t });
 
@@ -205,6 +205,28 @@ namespace DSharpPlus.SlashCommands
             });
         }
 
+        private async Task<List<DiscordApplicationCommandOptionChoice>> GetChoiceAttributesFromProvider(IEnumerable<ChoiceProviderAttribute> customAttributes)
+        {
+            var choices = new List<DiscordApplicationCommandOptionChoice>();
+            foreach (var choiceProviderAttribute in customAttributes)
+            {
+                var method = choiceProviderAttribute.ProviderType.GetMethod(nameof(IChoiceProvider.Provider));
+
+                if (method != null)
+                {
+                    var instance = Activator.CreateInstance(choiceProviderAttribute.ProviderType);
+                    var result = await (Task<IEnumerable<DiscordApplicationCommandOptionChoice>>) method.Invoke(instance, null);
+                    
+                    if (result.Any())
+                    {
+                        choices.AddRange(result);
+                    }
+                }
+            }
+
+            return choices;
+        }
+        
         private static List<DiscordApplicationCommandOptionChoice> GetChoiceAttributesFromEnumParameter(Type enumParam)
         {
             var choices = new List<DiscordApplicationCommandOptionChoice>();
@@ -437,7 +459,7 @@ namespace DSharpPlus.SlashCommands
             return choiceattributes.Select(att => new DiscordApplicationCommandOptionChoice(att.Name, att.Value)).ToList();
         }
 
-        private List<DiscordApplicationCommandOption> ParseParameters(ParameterInfo[] parameters)
+        private async Task<List<DiscordApplicationCommandOption>> ParseParameters(ParameterInfo[] parameters)
         {
             var options = new List<DiscordApplicationCommandOption>();
             foreach (var parameter in parameters)
@@ -454,6 +476,13 @@ namespace DSharpPlus.SlashCommands
                 if (parameter.ParameterType.IsEnum)
                 {
                     choices = GetChoiceAttributesFromEnumParameter(parameter.ParameterType);
+                }
+                
+                var choiceProviders = parameter.GetCustomAttributes<ChoiceProviderAttribute>();
+
+                if (choiceProviders.Any())
+                {
+                    choices = await GetChoiceAttributesFromProvider(choiceProviders);
                 }
 
                 options.Add(new DiscordApplicationCommandOption(optionattribute.Name, optionattribute.Description, parametertype, !parameter.IsOptional, choices));


### PR DESCRIPTION
This allows people to attach a "ChoiceProvider" to a commands options, this is useful if you want to load up options from a database for example. Decided to leave out any error handling, if shit breaks that's on the user for not handling it correctly themselves.

Feedback welcome and encouraged.

usage code:

```cs

    public class TestChoiceProvider : IChoiceProvider
    {
        public async Task<IEnumerable<DiscordApplicationCommandOptionChoice>> Provider()
        {
            return new DiscordApplicationCommandOptionChoice[]
            {
                new DiscordApplicationCommandOptionChoice("testing,","testing")
            };
        }
    }
    
    public class MiscCommands : SlashCommandModule
    {
        [SlashCommand("test", "test")]
        public async Task Testing(InteractionContext ctx,
            [ChoiceProvider(typeof(TestChoiceProvider))]
            [Option("option", "option")]
            string option)
        {
                await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new DiscordInteractionResponseBuilder().WithContent("pong"));

        }
   }
```