### PR TITLE
Adds Property Injection to non-static methods.

### DIFF
--- a/Attributes/DontInjectAttribute.cs
+++ b/Attributes/DontInjectAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace DSharpPlus.SlashCommands
+{
+    /// <summary>
+    /// Prevents this field or property from having its value injected by dependency injection.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class DontInjectAttribute : Attribute
+    { }
+}

--- a/README.md
+++ b/README.md
@@ -273,6 +273,20 @@ var slash = discord.UseSlashCommands(new SlashCommandsConfiguration
 });
 ```
 (Thanks to @sssvt-drabek-stepan for adding this)
+
+Property injection is implemented, however static properties will not be replaced. If you wish for a non-static property to be left alone, assign it the `DontInject` attribute. Property Injection can be used like so:
+```cs
+public class Commands : SlashCommandModule
+{
+    public Database Database { private get; set; } // The get accessor is optionally public, but the set accessor must be public.
+
+    [SlashCommand("ping", "Checks the latency between the bot and it's database. Best used to see if the bot is lagging.")]
+    public async Task Ping(InteractionContext context) => await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, new()
+    {
+        Content = $"Pong! Database latency is {Database.GetPing()}ms."
+    });
+}
+```
 ### Sharding
 `UseSlashCommands` -> `UseSlashCommmandsAsync` which returns a dictionary.
 


### PR DESCRIPTION
Using Commands Next `CreateInstance` method, non-static properties with a public set accessor will be replaced with previous existing objects obtained from the `ServiceProvider` from the configuration. Properties can be skipped by applying the `DontInject` attribute. The PR has been tested for commands, groups and subgroups. A small example usage has been attached to the README.