### PR TITLE
Add a way to block command execution through `BeforeExecutionAsync()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ public async Task TestCommand(InteractionContext ctx)
 }
 ```
 You can also override `BeforeExecutionAsync` and `AfterExecutionAsync` to run code before and after all the commands in a module. This does not apply to groups, you have the override them individually for the group's class.
+`BeforeExecutionAsync` can also be used to prevent the command from running.
+
 ### Arguments
 If you want the user to be able to give more data to the command, you can add some arguments.
 

--- a/SlashCommandModule.cs
+++ b/SlashCommandModule.cs
@@ -11,8 +11,9 @@ namespace DSharpPlus.SlashCommands
         /// Called before the execution of command in the module.
         /// </summary>
         /// <param name="ctx">The context.</param>
-        public virtual Task BeforeExecutionAsync(InteractionContext ctx)
-            => Task.CompletedTask;
+        /// <returns> Whether or not to execute the slash command. </returns>
+        public virtual Task<bool> BeforeExecutionAsync(InteractionContext ctx)
+            => Task.FromResult(true);
 
         /// <summary>
         /// Called after the execution of a command in the module.

--- a/SlashCommandsExtension.cs
+++ b/SlashCommandsExtension.cs
@@ -376,11 +376,14 @@ namespace DSharpPlus.SlashCommands
 
             await RunPreexecutionChecksAsync(method, context);
 
-            await (module?.BeforeExecutionAsync(context) ?? Task.CompletedTask);
+            var shouldExecute = await (module?.BeforeExecutionAsync(context) ?? Task.FromResult(true));
 
-            await (Task)method.Invoke(classinstance, args.ToArray());
+            if (shouldExecute)
+            {
+                await (Task)method.Invoke(classinstance, args.ToArray());
 
-            await (module?.AfterExecutionAsync(context) ?? Task.CompletedTask);
+                await (module?.AfterExecutionAsync(context) ?? Task.CompletedTask);
+            }
         }
 
         internal object CreateInstance(Type t, IServiceProvider services)


### PR DESCRIPTION
This adds a return value to the `SlashCommandModule.BeforeExecutionAsync()` method, which returns true by default. 
It is used to check whether or not to execute the slash command (returning false will stop it from executing). 

It's like a precondition except you can make it more tailored to a specific command module.