### PR TITLE
Implement DiscordEmoji parameter type support

### DIFF
--- a/SlashCommandsExtension.cs
+++ b/SlashCommandsExtension.cs
@@ -781,30 +781,29 @@ namespace DSharpPlus.SlashCommands
         //Small method to get the parameter's type from its type
         private ApplicationCommandOptionType GetParameterType(Type type)
         {
-            ApplicationCommandOptionType parametertype;
             if (type == typeof(string))
-                parametertype = ApplicationCommandOptionType.String;
+                return ApplicationCommandOptionType.String;
             else if (type == typeof(long) || type == typeof(long?))
-                parametertype = ApplicationCommandOptionType.Integer;
+                return ApplicationCommandOptionType.Integer;
             else if (type == typeof(bool) || type == typeof(bool?))
-                parametertype = ApplicationCommandOptionType.Boolean;
+                return ApplicationCommandOptionType.Boolean;
             else if (type == typeof(double) || type == typeof(double?))
-                parametertype = ApplicationCommandOptionType.Number;
+                return ApplicationCommandOptionType.Number;
             else if (type == typeof(DiscordChannel))
-                parametertype = ApplicationCommandOptionType.Channel;
+                return ApplicationCommandOptionType.Channel;
             else if (type == typeof(DiscordUser))
-                parametertype = ApplicationCommandOptionType.User;
+                return ApplicationCommandOptionType.User;
             else if (type == typeof(DiscordRole))
-                parametertype = ApplicationCommandOptionType.Role;
+                return ApplicationCommandOptionType.Role;
+            else if (type == typeof(DiscordEmoji))
+                return ApplicationCommandOptionType.String;
             else if (type == typeof(SnowflakeObject))
-                parametertype = ApplicationCommandOptionType.Mentionable;
+                return ApplicationCommandOptionType.Mentionable;
             else if (type.IsEnum)
-                parametertype = ApplicationCommandOptionType.String;
+                return ApplicationCommandOptionType.String;
 
             else
                 throw new ArgumentException("Cannot convert type! Argument types must be string, long, bool, double, DiscordChannel, DiscordUser, DiscordRole, SnowflakeObject or an Enum.");
-
-            return parametertype;
         }
 
         //Gets choices from choice attributes

--- a/SlashCommandsExtension.cs
+++ b/SlashCommandsExtension.cs
@@ -666,8 +666,17 @@ namespace DSharpPlus.SlashCommands
                         else
                             throw new ArgumentException("Error resolving mentionable option.");
                     }
+					else if (parameter.ParameterType == typeof(DiscordEmoji))
+					{
+                        var value = option.Value.ToString();
+
+                        if (DiscordEmoji.TryFromUnicode(Client, value, out var emoji) || DiscordEmoji.TryFromName(Client, value, out emoji))
+                            args.Add(emoji);
+                        else
+                            throw new ArgumentException("Error parsing emoji parameter.");
+					}
                     else
-                        throw new ArgumentException($"Error resolving interaction.");
+                        throw new ArgumentException("Error resolving interaction.");
                 }
             }
 
@@ -846,7 +855,7 @@ namespace DSharpPlus.SlashCommands
         }
 
         /// <summary>
-        /// <para>Refreshes your commands, used for refreshing choice providers or applying commands registered after the ready event on the discord client. 
+        /// <para>Refreshes your commands, used for refreshing choice providers or applying commands registered after the ready event on the discord client.
         /// Should only be run on the slash command extension linked to shard 0 if sharding.</para>
         /// <para>Not recommended and should be avoided since it can make slash commands be unresponsive for a while.</para>
         /// </summary>


### PR DESCRIPTION
Added support for `DiscordEmoji` as a parameter type for commands. 
Backed by string on Discord API, given that Discord has, as of yet, no support for Emojis alone.