### PR TITLE
Set LangVersion to latest

### DIFF
--- a/DSharpPlus.SlashCommands.csproj
+++ b/DSharpPlus.SlashCommands.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <Authors>IDoEverything, Epictek, sssvt-drabek-stepan, tygore587, VelvetThePanda, OoLunar</Authors>
     <Description>An extension for DSharpPlus to make slash commands easy</Description>
     <PackageLicenseFile></PackageLicenseFile>


### PR DESCRIPTION
Setting LangVersion to latest allows for the use of latest C# 9.0 language features, without retargeting the library to .NET 5.