### PR TITLE
Added abstract ChoiceProvider to inject Services and GuildId

### DIFF
--- a/ChoiceProvider.cs
+++ b/ChoiceProvider.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.SlashCommands
+{
+    /// <summary>
+    /// Implementation of <see cref="IChoiceProvider"/> with access to service collection.
+    /// </summary>
+    public abstract class ChoiceProvider : IChoiceProvider
+    {
+        /// <summary>
+        /// Sets the choices for the slash command.
+        /// </summary>
+        public abstract Task<IEnumerable<DiscordApplicationCommandOptionChoice>> Provider();
+
+        /// <summary>
+        /// Sets the service provider.
+        /// </summary>
+        public IServiceProvider Services { get; set; }
+
+        /// <summary>
+        /// The optional ID of the Guild the command got registered for.
+        /// </summary>
+        public ulong? GuildId { get; set; }
+    }
+}

--- a/SlashCommandsExtension.cs
+++ b/SlashCommandsExtension.cs
@@ -747,7 +747,10 @@ namespace DSharpPlus.SlashCommands
         }
 
         //Gets the choices from a choice provider
-        private async Task<List<DiscordApplicationCommandOptionChoice>> GetChoiceAttributesFromProvider(IEnumerable<ChoiceProviderAttribute> customAttributes)
+        private async Task<List<DiscordApplicationCommandOptionChoice>> GetChoiceAttributesFromProvider(
+            IEnumerable<ChoiceProviderAttribute> customAttributes,
+            ulong? guildId
+        )
         {
             var choices = new List<DiscordApplicationCommandOptionChoice>();
             foreach (var choiceProviderAttribute in customAttributes)
@@ -759,6 +762,17 @@ namespace DSharpPlus.SlashCommands
                 else
                 {
                     var instance = Activator.CreateInstance(choiceProviderAttribute.ProviderType);
+
+                    // Abstract class offers more properties that can be set
+                    if (choiceProviderAttribute.ProviderType.IsSubclassOf(typeof(ChoiceProvider)))
+                    {
+                        choiceProviderAttribute.ProviderType.GetProperty(nameof(ChoiceProvider.GuildId))
+                            ?.SetValue(instance, guildId);
+
+                        choiceProviderAttribute.ProviderType.GetProperty(nameof(ChoiceProvider.Services))
+                            ?.SetValue(instance, _configuration.Services);
+                    }
+
                     //Gets the choices from the method
                     var result = await (Task<IEnumerable<DiscordApplicationCommandOptionChoice>>)method.Invoke(instance, null);
 
@@ -850,7 +864,7 @@ namespace DSharpPlus.SlashCommands
                 var choiceProviders = parameter.GetCustomAttributes<ChoiceProviderAttribute>();
                 if (choiceProviders.Any())
                 {
-                    choices = await GetChoiceAttributesFromProvider(choiceProviders);
+                    choices = await GetChoiceAttributesFromProvider(choiceProviders, guildId);
                 }
 
                 options.Add(new DiscordApplicationCommandOption(optionattribute.Name, optionattribute.Description, parametertype, !parameter.IsOptional, choices));


### PR DESCRIPTION
I've added the abstract class `ChoiceProvider` with `Services` and `GuildId` properties you can derive from instead of `IChoiceProvider` and `GetChoiceAttributesFromProvider` will transparently set the properties for consumption in the resulting choice provider.

My use case for this was to access the DI service collection from within a choice provider to get convenient access to my database context.

Cheers